### PR TITLE
Add University Service and Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/config/SpringFoxConfig.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/config/SpringFoxConfig.java
@@ -10,20 +10,94 @@ import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.core.env.Environment;
+
+import org.springframework.boot.actuate.endpoint.web.servlet.WebMvcEndpointHandlerMapping;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
+import org.springframework.boot.actuate.endpoint.web.EndpointLinksResolver;
+import org.springframework.boot.actuate.endpoint.web.EndpointMapping;
+import org.springframework.boot.actuate.endpoint.web.EndpointMediaTypes;
+import org.springframework.boot.actuate.endpoint.web.ExposableWebEndpoint;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpointsSupplier;
+import org.springframework.util.StringUtils;
+
 /**
  * Configuration for Swagger, a package that provides documentation
  * for REST API endpoints.
- * @see <a href="https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api">https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api</a>
+ * 
+ * @see <a href=
+ *      "https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api">https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api</a>
  */
 
 @Configuration
-public class SpringFoxConfig {                                    
+public class SpringFoxConfig {
+
+    /*
+     * This is a bean that defines the "docket" for Swagger. It is a
+     * configuration object that tells Swagger what to document.
+     */
     @Bean
-    public Docket api() { 
-        return new Docket(DocumentationType.SWAGGER_2)  
-          .select()                                  
-          .apis(RequestHandlerSelectors.any())  
-          .paths(Predicate.not(PathSelectors.regex("/error.*")))//<6>, regex must be in double quotes.            
-          .build();                                           
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(Predicate.not(PathSelectors.regex("/error.*")))// <6>, regex must be in double quotes.
+                .build();
+    }
+
+    /**
+     * This is a workaround for a bug in SpringFox
+     * 
+     * @see <a href=
+     *      "https://stackoverflow.com/a/70892119">https://stackoverflow.com/a/70892119</a>
+     *
+     * 
+     * @param webEndpointsSupplier
+     * @param servletEndpointsSupplier
+     * @param controllerEndpointsSupplier
+     * @param endpointMediaTypes
+     * @param corsProperties
+     * @param webEndpointProperties
+     * @param environment
+     * @return
+     */
+
+    @Bean
+    public WebMvcEndpointHandlerMapping webEndpointServletHandlerMapping(WebEndpointsSupplier webEndpointsSupplier,
+            ServletEndpointsSupplier servletEndpointsSupplier, ControllerEndpointsSupplier controllerEndpointsSupplier,
+            EndpointMediaTypes endpointMediaTypes, CorsEndpointProperties corsProperties,
+            WebEndpointProperties webEndpointProperties, Environment environment) {
+        List<ExposableEndpoint<?>> allEndpoints = new ArrayList<ExposableEndpoint<?>>();
+        Collection<ExposableWebEndpoint> webEndpoints = webEndpointsSupplier.getEndpoints();
+        allEndpoints.addAll(webEndpoints);
+        allEndpoints.addAll(servletEndpointsSupplier.getEndpoints());
+        allEndpoints.addAll(controllerEndpointsSupplier.getEndpoints());
+        String basePath = webEndpointProperties.getBasePath();
+        EndpointMapping endpointMapping = new EndpointMapping(basePath);
+        boolean shouldRegisterLinksMapping = this.shouldRegisterLinksMapping(webEndpointProperties, environment,
+                basePath);
+        return new WebMvcEndpointHandlerMapping(endpointMapping, webEndpoints, endpointMediaTypes,
+                corsProperties.toCorsConfiguration(), new EndpointLinksResolver(allEndpoints, basePath),
+                shouldRegisterLinksMapping);
+    }
+
+    /*
+     * This is a workaround for a bug in SpringFox
+     * See https://stackoverflow.com/a/70892119
+     */
+
+    private boolean shouldRegisterLinksMapping(WebEndpointProperties webEndpointProperties, Environment environment,
+            String basePath) {
+        return webEndpointProperties.getDiscovery().isEnabled() && (StringUtils.hasText(basePath)
+                || ManagementPortType.get(environment).equals(ManagementPortType.DIFFERENT));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
@@ -1,9 +1,39 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+
+@Api(description="University info from universities.hipolabs.com")
+@Slf4j
 @RestController
+@RequestMapping("/api/university/get")
 public class UniversityController {
-    
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    UniversityQueryService universityQueryService;
+
+    @ApiOperation(value="Get list of universities that match a given name", notes="Country data uploaded to OpenDataSoft by the International Labour Organization")
+    @GetMapping("/get")
+    public ResponseEntity<String> getUniversity(
+        @ApiParam("name to search, e.g. 'Harvard' or 'Stanford'") @RequestParam String name
+    ) throws JsonProcessingException {
+        log.info("getUniversity: name={}", name);
+        String result = universityQueryService.getJSON(name);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
@@ -20,7 +20,7 @@ import io.swagger.annotations.ApiParam;
 @Api(description="University info from universities.hipolabs.com")
 @Slf4j
 @RestController
-@RequestMapping("/api/university/get")
+@RequestMapping("/api/university")
 public class UniversityController {
     ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
@@ -27,7 +27,7 @@ public class UniversityController {
     @Autowired
     UniversityQueryService universityQueryService;
 
-    @ApiOperation(value="Get list of universities that match a given name", notes="Country data uploaded to OpenDataSoft by the International Labour Organization")
+    @ApiOperation(value="Get list of universities that match a given name", notes="Uses API documented here: http://universities.hipolabs.com/search")
     @GetMapping("/get")
     public ResponseEntity<String> getUniversity(
         @ApiParam("name to search, e.g. 'Harvard' or 'Stanford'") @RequestParam String name

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
@@ -24,7 +24,7 @@ public class UniversityQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "http://universities.hipolabs.com/search?name={name}";
 
     public String getJSON(String name) throws HttpClientErrorException {
        return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
-
+import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -9,7 +10,11 @@ import org.springframework.web.client.RestTemplate;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
-
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -17,6 +22,7 @@ import org.springframework.web.client.HttpClientErrorException;
 @Service
 public class UniversityQueryService {
 
+    ObjectMapper mapper = new ObjectMapper();
 
     private final RestTemplate restTemplate;
 
@@ -27,6 +33,17 @@ public class UniversityQueryService {
     public static final String ENDPOINT = "http://universities.hipolabs.com/search?name={name}";
 
     public String getJSON(String name) throws HttpClientErrorException {
-       return "";
+       log.info("name={}", name);
+       HttpHeaders headers = new HttpHeaders();
+       headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+       headers.setContentType(MediaType.APPLICATION_JSON);
+
+       Map<String, String> uriVariables = Map.of("name", name);
+
+       HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+       ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+               uriVariables);
+       return re.getBody();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 server.port=${PORT:8080}
+spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
@@ -1,0 +1,49 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(value = UniversityController.class)
+public class UniversityControllerTests {
+private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  UniversityQueryService mockUniversityQueryService;
+
+  @Test
+  public void test_getUniversity() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String name = "Harvard";
+    when(mockUniversityQueryService.getJSON(eq(name))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/university/get?name=%s", name);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
@@ -13,20 +13,20 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 
-@RestClientTest(CountryCodeQueryService.class)
+@RestClientTest(UniversityQueryService.class)
 public class UniversityQueryServiceTests {
 
     @Autowired
     private MockRestServiceServer mockRestServiceServer;
 
     @Autowired
-    private CountryCodeQueryService countryCodeQueryService;
+    private UniversityQueryService universityQueryService;
 
     @Test
     public void test_getJSON() {
 
         String name = "Harvard";
-        String expectedURL = CountryCodeQueryService.ENDPOINT.replace("{name}", name);
+        String expectedURL = UniversityQueryService.ENDPOINT.replace("{name}", name);
 
         String fakeJsonResult = "{ \"fake\" : \"result\" }";
 
@@ -35,7 +35,7 @@ public class UniversityQueryServiceTests {
                 .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
                 .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
 
-        String actualResult = countryCodeQueryService.getJSON(name);
+        String actualResult = universityQueryService.getJSON(name);
         assertEquals(fakeJsonResult, actualResult);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
@@ -38,4 +38,21 @@ public class UniversityQueryServiceTests {
         String actualResult = universityQueryService.getJSON(name);
         assertEquals(fakeJsonResult, actualResult);
     }
+
+    @Test
+    public void test_getJSON1() {
+
+        String name = "Stanford";
+        String expectedURL = UniversityQueryService.ENDPOINT.replace("{name}", name);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = universityQueryService.getJSON(name);
+        assertEquals(fakeJsonResult, actualResult);
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(CountryCodeQueryService.class)
+public class UniversityQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private CountryCodeQueryService countryCodeQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String name = "Harvard";
+        String expectedURL = CountryCodeQueryService.ENDPOINT.replace("{name}", name);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = countryCodeQueryService.getJSON(name);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/university/get` that can be used to get information
about the website a particular university.  